### PR TITLE
Pacman come una fruta

### DIFF
--- a/src/main/java/gradle/cucumber/Fruta.java
+++ b/src/main/java/gradle/cucumber/Fruta.java
@@ -1,0 +1,4 @@
+package gradle.cucumber;
+
+public class Fruta {
+}

--- a/src/main/java/gradle/cucumber/Pacman.java
+++ b/src/main/java/gradle/cucumber/Pacman.java
@@ -1,8 +1,12 @@
 package gradle.cucumber;
 
 public class Pacman {
+
     public void come(Biscuit biscuit) {
 
+    }
+
+    public void come(Fruta fruta) {
 
     }
 
@@ -11,6 +15,7 @@ public class Pacman {
     }
 
     public int puntaje() {
+
         return 5;
     }
 }

--- a/src/test/java/gradle/cucumber/PacmanCucumber.java
+++ b/src/test/java/gradle/cucumber/PacmanCucumber.java
@@ -5,12 +5,11 @@ import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import junit.framework.TestCase;
 
-
 public class PacmanCucumber {
-
 
     private Pacman pacman = new Pacman();
     private Biscuit biscuit = new Biscuit();
+    private Fruta fruta = new Fruta();
 
     @Given("^Pacman come un biscuit$")
     public void pacmanComeUnBiscuit()  {
@@ -27,7 +26,13 @@ public class PacmanCucumber {
 
     @Then("^Suma puntos (\\d+)$")
     public void sumaPuntos(int puntosEsperados)  {
-        TestCase.assertEquals(puntosEsperados, pacman.puntaje());
 
+        TestCase.assertEquals(puntosEsperados, pacman.puntaje());
+    }
+
+    @Given("^Pacman come una fruta$")
+    public void pacmanComeUnaFruta() throws Throwable {
+
+        pacman.come(fruta);
     }
 }

--- a/src/test/resources/gradle/cucumber/pacman.feature
+++ b/src/test/resources/gradle/cucumber/pacman.feature
@@ -4,3 +4,7 @@ Feature:  Cuando el pacman come
     Given Pacman come un biscuit
     When Se vuelve más gordo
     Then Suma puntos 5
+
+    Given Pacman come una fruta
+    When Se vuelve más gordo
+    Then Suma puntos 5


### PR DESCRIPTION
## Motivo

El Pacman come una fruta.
Al no estar modelado el caso se debe agregar.

## Solución

Se genero una lógica similar a la que estaba para el biscuit.